### PR TITLE
Added creator validation for the editing of elections

### DIFF
--- a/ballot_box_web/app/controllers/elections_controller.rb
+++ b/ballot_box_web/app/controllers/elections_controller.rb
@@ -11,6 +11,7 @@ class ElectionsController < ApplicationController
     def create
         @election = Election.new(election_params)
         @election.creator = current_user.email
+        @election.show_election_id = (0...10).map{65.+(rand(26)).chr}.join
 
         if @election.save
             redirect_to @election
@@ -20,15 +21,15 @@ class ElectionsController < ApplicationController
     end
 
     def show
-        @election = Election.find(params[:id])
+        @election = Election.find_by_show_election_id(params[:show_election_id])
     end
 
     def edit
-        @election = Election.find(params[:id])
+        @election = Election.find_by_show_election_id(params[:show_election_id])
     end
     
     def update
-        @election = Election.find(params[:id])
+        @election = Election.find_by_show_election_id(params[:show_election_id])
 
         if @election.update(election_params)
             redirect_to @election
@@ -38,7 +39,7 @@ class ElectionsController < ApplicationController
     end
 
     def destroy
-        @election = Election.find(params[:id])
+        @election = Election.find_by_show_election_id(params[:show_election_id])
         @election.destroy
 
         redirect_to elections_path

--- a/ballot_box_web/app/controllers/elections_controller.rb
+++ b/ballot_box_web/app/controllers/elections_controller.rb
@@ -11,7 +11,7 @@ class ElectionsController < ApplicationController
     def create
         @election = Election.new(election_params)
         @election.creator = current_user.email
-        @election.show_election_id = (0...10).map{65.+(rand(26)).chr}.join
+        @election.random_id = (0...10).map{65.+(rand(26)).chr}.join
 
         if @election.save
             redirect_to @election
@@ -21,15 +21,15 @@ class ElectionsController < ApplicationController
     end
 
     def show
-        @election = Election.find_by_show_election_id(params[:show_election_id])
+        @election = Election.find_by_random_id(params[:random_id])
     end
 
     def edit
-        @election = Election.find_by_show_election_id(params[:show_election_id])
+        @election = Election.find_by_random_id(params[:random_id])
     end
     
     def update
-        @election = Election.find_by_show_election_id(params[:show_election_id])
+        @election = Election.find_by_random_id(params[:random_id])
 
         if @election.update(election_params)
             redirect_to @election
@@ -39,7 +39,7 @@ class ElectionsController < ApplicationController
     end
 
     def destroy
-        @election = Election.find_by_show_election_id(params[:show_election_id])
+        @election = Election.find_by_random_id(params[:random_id])
         @election.destroy
 
         redirect_to elections_path

--- a/ballot_box_web/app/models/election.rb
+++ b/ballot_box_web/app/models/election.rb
@@ -1,9 +1,10 @@
 class Election < ActiveRecord::Base
     def to_param
-        show_election_id
+        random_id
     end
     has_many :choices
     accepts_nested_attributes_for :choices, allow_destroy: true
+    validates_uniqueness_of :random_id
 
     attr_accessible :title, :text, :choices_attributes, :private
 end

--- a/ballot_box_web/app/models/election.rb
+++ b/ballot_box_web/app/models/election.rb
@@ -1,4 +1,7 @@
 class Election < ActiveRecord::Base
+    def to_param
+        show_election_id
+    end
     has_many :choices
     accepts_nested_attributes_for :choices, allow_destroy: true
 

--- a/ballot_box_web/app/views/elections/edit.html.erb
+++ b/ballot_box_web/app/views/elections/edit.html.erb
@@ -11,24 +11,30 @@
             </ul>
         </div>
     <% end %>
-    <p>
-        <%= f.label :title %><br />
-        <%= f.text_field :title %>
-    </p>
-    <p>
-        <%= f.label :text %><br />
-        <%= f.text_area :text %>
-    </p>
-    <h2>Choices</h2>
-    <%= f.fields_for :choices do |ff| %>
-        <div>
-            <%= ff.label :body %>
-            <%= ff.text_field :body %>
-        </div>
+    <% if current_user.email == @election.creator %>
+        <p>
+            <%= f.label :title %><br />
+            <%= f.text_field :title %>
+        </p>
+        <p>
+            <%= f.label :text %><br />
+            <%= f.text_area :text %>
+        </p>
+        <h2>Choices</h2>
+        <%= f.fields_for :choices do |ff| %>
+            <div>
+                <%= ff.label :body %>
+                <%= ff.text_field :body %>
+            </div>
+        <% end %>
+        <p>
+            <%= f.submit %>
+        </p>
+    <% else %>
+        <p>
+            You can't edit an election you don't own!
+        </p>
     <% end %>
-    <p>
-        <%= f.submit %>
-    </p>
 <% end %>
 
 <%= link_to 'Back', elections_path %>

--- a/ballot_box_web/app/views/elections/show.html.erb
+++ b/ballot_box_web/app/views/elections/show.html.erb
@@ -19,9 +19,9 @@
             <p>
                 <%= choice.body %>
                 <% if current_user && !choice.has_evaluation?(:votes, current_user) %>
-                    | <%= link_to "Vote for this!", vote_election_choice_path(election_id: choice.election_id, id: choice.id, type: "up"), method: "post" %>
+                    | <%= link_to "Vote for this!", vote_election_choice_path(election_random_id: @election.random_id, id: choice.id, type: "up"), method: "post" %>
                 <% else %>
-                    | <%= link_to "Cancel vote", vote_election_choice_path(election_id: choice.election_id, id: choice.id, type: "down"), method: "post" %>
+                    | <%= link_to "Cancel vote", vote_election_choice_path(election_random_id: @election.random_id, id: choice.id, type: "down"), method: "post" %>
                 <% end %>
             </p>
         <% end %>

--- a/ballot_box_web/app/views/elections/show.html.erb
+++ b/ballot_box_web/app/views/elections/show.html.erb
@@ -20,6 +20,7 @@
                 <%= choice.body %>
                 <% if current_user && !choice.has_evaluation?(:votes, current_user) %>
                     | <%= link_to "Vote for this!", vote_election_choice_path(election_id: choice.election_id, id: choice.id, type: "up"), method: "post" %>
+                <% else %>
                     | <%= link_to "Cancel vote", vote_election_choice_path(election_id: choice.election_id, id: choice.id, type: "down"), method: "post" %>
                 <% end %>
             </p>

--- a/ballot_box_web/config/routes.rb
+++ b/ballot_box_web/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :elections do
+  resources :elections, param: :show_election_id do
       resources :choices do 
           member { post :vote }
       end

--- a/ballot_box_web/config/routes.rb
+++ b/ballot_box_web/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :elections, param: :show_election_id do
+  resources :elections, param: :random_id do
       resources :choices do 
           member { post :vote }
       end

--- a/ballot_box_web/db/schema.rb
+++ b/ballot_box_web/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20141104215053) do
     t.datetime "updated_at"
     t.string   "creator"
     t.boolean  "private"
+    t.string   "show_election_id"
   end
 
   create_table "rs_evaluations", force: true do |t|

--- a/ballot_box_web/db/schema.rb
+++ b/ballot_box_web/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20141104215053) do
     t.datetime "updated_at"
     t.string   "creator"
     t.boolean  "private"
-    t.string   "show_election_id"
+    t.string   "random_id"
   end
 
   create_table "rs_evaluations", force: true do |t|


### PR DESCRIPTION
A tiny bit of security added to prevent people who don't own elections from editing those elections.  It's just a simple validation check like the one to give the link.  If this doesn't exist, the user can simply type "edit" into the url bar and be able to edit any vote's contents.

In addition, the number in the url bar was changed to random strings, so a person can't find a private election (or loop through all elections) just by putting a random sequence of numbers through the url bar.

Finally, I fixed what I thought was a small bug where "Vote" and "Cancel Vote" appeared at the same time when a choice wasn't selected, and nothing appeared when it was.