### PR TITLE
Linking to separate Respositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Features Implemented:
 
 Features In Progress:
 * Mobile apps - Android & iPhone
+Android app repository: [https://github.com/breadknock/ballotbox-android]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Features Implemented:
 Features In Progress:
 * Mobile apps - Android & iPhone
 
-Android app repository: https://github.com/breadknock/ballotbox-android
+Android app repository: https://github.com/ballotbox/ballotbox-android
 
 IOS app repository: https://github.com/JGrippo/BallotBoxiOS

--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@ Features Implemented:
 
 Features In Progress:
 * Mobile apps - Android & iPhone
-Android app repository: [https://github.com/breadknock/ballotbox-android]
+
+Android app repository: https://github.com/breadknock/ballotbox-android
+
+IOS app repository: https://github.com/JGrippo/BallotBoxiOS


### PR DESCRIPTION
It's probably neater to use separate repositories for each part of the app; this also allows us to work separately.
Also, most deploying services like using the entire repository, if we use Heroku or something else.
